### PR TITLE
add optional iface parameter to btle

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ More options are:
 - name (string)(Optional)
   The name displayed in the frontend.
   
+- iface (integer)(Optional)
+  Parameter allows select of connection Bluetooth interface.
+  On Linux, 0 means */dev/hci0*, 1 means */dev/hci1* and so on.
+  
 Even more options regarding caching and intervals are comming in the future.
 
 For advanced debugging set:

--- a/custom_components/mikettle/sensor.py
+++ b/custom_components/mikettle/sensor.py
@@ -35,6 +35,7 @@ DEFAULT_PRODUCT_ID = 275
 DEFAULT_FORCE_UPDATE = False
 DEFAULT_NAME = "Mi Kettle"
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=60)
+DEFAULT_IFACE = 0
 
 # Sensor types are defined like: Name, units, icon
 SENSOR_TYPES = {
@@ -55,7 +56,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(CONF_PRODUCT_ID, default=DEFAULT_PRODUCT_ID): cv.positive_int,
         vol.Optional(CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE): cv.boolean,
-        vol.Optional(CONF_IFACE, default=None): cv.positive_int,
+        vol.Optional(CONF_IFACE, default=DEFAULT_IFACE): cv.positive_int,
     }
 )
 

--- a/custom_components/mikettle/sensor.py
+++ b/custom_components/mikettle/sensor.py
@@ -29,6 +29,7 @@ from homeassistant.helpers.entity import Entity
 _LOGGER = logging.getLogger(__name__)
 
 CONF_PRODUCT_ID = "product_id"
+CONF_IFACE = "iface"
 
 DEFAULT_PRODUCT_ID = 275
 DEFAULT_FORCE_UPDATE = False
@@ -54,6 +55,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(CONF_PRODUCT_ID, default=DEFAULT_PRODUCT_ID): cv.positive_int,
         vol.Optional(CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE): cv.boolean,
+        vol.Optional(CONF_IFACE, default=None): cv.positive_int,
     }
 )
 
@@ -61,7 +63,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the MiKettle sensor."""
     cache = config.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL).total_seconds()
-    poller = MiKettle(config.get(CONF_MAC), config.get(CONF_PRODUCT_ID))
+    poller = MiKettle(mac=config.get(CONF_MAC), product_id=config.get(CONF_PRODUCT_ID), iface=config.get(CONF_IFACE))
 
     force_update = config.get(CONF_FORCE_UPDATE)
 


### PR DESCRIPTION
Allows use of several bluetooth controllers on Home Assistant.
This integration will not work if it uses same controller as integration [mitempt_bt](https://github.com/custom-components/sensor.mitemp_bt), for example.
With this change it is possible to use dedicated controller for mikettle.

PS: Default value for btle is 'iface=None', but hass validation doesn't except None for parameter with "cv.positive_int" :(